### PR TITLE
Add says_it_implements?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.0.2
+
+  * Add `Class.says_it_implements?` for quickly checking whether a class says it is implementing a given interface. This doesn't perform the full method/params checking that happens on `.check_it_implements`.
+  * Make `.check_it_implements` available on any class
+
 0.0.1
 
   * Initial release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    duckface (0.0.1)
+    duckface-interfaces (0.0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -146,7 +146,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (>= 1.13)
-  duckface!
+  duckface-interfaces!
   guard-livereload
   guard-rspec
   pry-byebug

--- a/lib/duckface/implementation_methods.rb
+++ b/lib/duckface/implementation_methods.rb
@@ -5,5 +5,9 @@ module Duckface
     def check_it_implements(interface_class)
       Duckface::Services::CheckClassImplementsInterface.new(self, interface_class).perform
     end
+
+    def says_it_implements?(interface_class)
+      included_modules.include?(interface_class)
+    end
   end
 end

--- a/lib/duckface/object_sugar.rb
+++ b/lib/duckface/object_sugar.rb
@@ -4,8 +4,16 @@ require 'duckface/services/check_class_implements_interface'
 require 'duckface/implementation_methods'
 
 module Duckface
-  # Provides methods on any class for indicate usage of interfaces
+  # Provides methods on any class to indicate usage of interfaces
   module ObjectSugar
+    def check_it_implements(_interface_class)
+      false
+    end
+
+    def says_it_implements?(_interface_class)
+      false
+    end
+
     def implements_interface(interface_class)
       extend Duckface::ImplementationMethods
       include interface_class
@@ -13,4 +21,4 @@ module Duckface
   end
 end
 
-Object.extend(Duckface::ObjectSugar)
+Class.include(Duckface::ObjectSugar)

--- a/lib/duckface/version.rb
+++ b/lib/duckface/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Duckface
-  VERSION = '0.0.1'
+  VERSION = '0.0.2'
 end

--- a/spec/lib/duckface/object_sugar_spec.rb
+++ b/spec/lib/duckface/object_sugar_spec.rb
@@ -16,17 +16,31 @@ module Duckface
       implements_interface ExampleInterface
     end
 
+    class ExampleThatDoesNotImplementInterface
+      def hello; end
+    end
+
+    module AnotherExampleInterface
+      include Duckface::ActsAsInterface
+
+      def another_method; end
+    end
+
     describe '.implements_interface' do
       specify do
         expect(ExampleImplementation.included_modules).to include(ExampleInterface)
-        expect(ExampleImplementation.singleton_class.included_modules).to include(Duckface::ImplementationMethods)
+        expect(ExampleImplementation.singleton_class.included_modules)
+          .to include(Duckface::ImplementationMethods)
       end
     end
 
     describe '.check_it_implements' do
       subject(:check_it_implements) do
-        ExampleImplementation.check_it_implements(ExampleInterface)
+        implementation_class.check_it_implements(interface)
       end
+
+      let(:implementation_class) { ExampleImplementation }
+      let(:interface) { ExampleInterface }
 
       let(:check_class_implements_interface_service) do
         instance_double(Services::CheckClassImplementsInterface)
@@ -37,13 +51,66 @@ module Duckface
           .to receive(:new)
           .with(ExampleImplementation, ExampleInterface)
           .and_return(check_class_implements_interface_service)
+        allow(Services::CheckClassImplementsInterface)
+          .to receive(:new)
+          .with(ExampleImplementation, AnotherExampleInterface)
+          .and_return(check_class_implements_interface_service)
       end
 
-      specify do
-        expect(check_class_implements_interface_service)
-          .to receive(:perform)
-          .and_return(true)
-        expect(check_it_implements).to be true
+      context 'when the class does not implement any interfaces' do
+        let(:implementation_class) { ExampleThatDoesNotImplementInterface }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the class does implement the given interface' do
+        let(:implementation_class) { ExampleImplementation }
+
+        specify do
+          expect(check_class_implements_interface_service)
+            .to receive(:perform)
+            .and_return(true)
+          expect(check_it_implements).to be true
+        end
+      end
+
+      context 'when the class does not implement the given interface' do
+        let(:interface) { AnotherExampleInterface }
+
+        specify do
+          expect(check_class_implements_interface_service)
+            .to receive(:perform)
+            .and_return(false)
+          expect(check_it_implements).to be false
+        end
+      end
+    end
+
+    describe '.says_it_implements?' do
+      subject(:says_it_implements?) do
+        implementation_class.says_it_implements?(interface)
+      end
+
+      let(:interface) { ExampleInterface }
+      let(:implementation_class) { ExampleThatDoesNotImplementInterface }
+
+      context 'when a class does not implement any interfaces' do
+        let(:implementation_class) { ExampleThatDoesNotImplementInterface }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when a class implements the given interface' do
+        let(:implementation_class) { ExampleImplementation }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when a class does not implement the given interface' do
+        let(:implementation_class) { ExampleImplementation }
+        let(:interface) { AnotherExampleInterface }
+
+        it { is_expected.to be false }
       end
     end
   end


### PR DESCRIPTION
This PR adds `Class.says_it_implements?` for quickly checking whether a class says it is implementing a given interface. This doesn't perform the full method/params checking that happens on `.check_it_implements`. This is useful for say a factory that performs logic based on whether a given class implements an interface.

This PR also makes `.check_it_implements` available on any class.