### PR TITLE
Add support for checking Dry::Struct based implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.0.4
+
+  * Add support for checking Dry::Struct's against an interface
+
 0.0.3
 
   * `Class.check_it_implements` now returns a `CheckSession`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
       http_parser.rb (~> 0.6.0)
     equalizer (0.0.11)
     eventmachine (1.2.3)
-    ffi (1.9.18)
+    ffi (1.9.25)
     formatador (0.2.5)
     guard (2.14.1)
       formatador (>= 0.2.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    duckface-interfaces (0.0.2)
+    duckface-interfaces (0.0.4)
 
 GEM
   remote: https://rubygems.org/
@@ -166,4 +166,4 @@ DEPENDENCIES
   spring-watcher-listen
 
 BUNDLED WITH
-   1.16.4
+   1.16.5

--- a/lib/duckface/method_implementation.rb
+++ b/lib/duckface/method_implementation.rb
@@ -11,17 +11,36 @@ module Duckface
     end
 
     def parameters_for_comparison
-      @parameters_for_comparison ||= ParameterPairs.new(parameters).for_comparison
+      @parameters_for_comparison ||= begin
+        return [] if present_in_schema?
+
+        ParameterPairs.new(parameters).for_comparison
+      end
     end
 
     def owner
-      @owner ||= implementation.owner
+      @owner ||= begin
+        return @klass if present_in_schema?
+
+        implementation.owner
+      end
     end
 
     private
 
     def implementation
       @implementation ||= @klass.public_instance_method(@method_name)
+    end
+
+    def present_in_schema?
+      return false unless schema?
+      @klass.schema.keys.include?(@method_name)
+    end
+
+    def schema?
+      return false unless @klass.respond_to?(:schema)
+
+      @klass.schema.respond_to?(:keys)
     end
 
     def parameters

--- a/lib/duckface/version.rb
+++ b/lib/duckface/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Duckface
-  VERSION = '0.0.3'
+  VERSION = '0.0.4'
 end

--- a/spec/lib/duckface/method_implementation_spec.rb
+++ b/spec/lib/duckface/method_implementation_spec.rb
@@ -11,6 +11,14 @@ module Duckface
       end
     end
 
+    class ExampleStruct
+      def self.schema
+        {
+          my_struct_attribute: 'String'
+        }
+      end
+    end
+
     let(:method_implementation) { MethodImplementation.new(ExampleMethodTest, :some_method) }
 
     describe '#parameters_for_comparison' do
@@ -30,12 +38,24 @@ module Duckface
       end
 
       it { is_expected.to eq parameter_pairs_for_comparison }
+
+      context 'with a struct' do
+        let(:method_implementation) { MethodImplementation.new(ExampleStruct, :my_struct_attribute) }
+
+        it { is_expected.to eq [] }
+      end
     end
 
     describe '#owner' do
       subject(:owner) { method_implementation.owner }
 
       it { is_expected.to eq ExampleMethodTest }
+
+      context 'with a struct' do
+        let(:method_implementation) { MethodImplementation.new(ExampleStruct, :my_struct_attribute) }
+
+        it { is_expected.to eq ExampleStruct }
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds basic support for checking that a `Dry::Struct` based implementation correctly implements an interface.