### PR TITLE
Explicitly require forwardable to prevent explosions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.0.5
+
+  * Add support for dry-struct >= 0.6.0
+
 0.0.4
 
   * Add support for checking Dry::Struct's against an interface

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    duckface-interfaces (0.0.4)
+    duckface-interfaces (0.0.5)
 
 GEM
   remote: https://rubygems.org/
@@ -166,4 +166,4 @@ DEPENDENCIES
   spring-watcher-listen
 
 BUNDLED WITH
-   1.16.5
+   1.17.1

--- a/lib/duckface/method_implementation.rb
+++ b/lib/duckface/method_implementation.rb
@@ -34,7 +34,15 @@ module Duckface
 
     def present_in_schema?
       return false unless schema?
-      @klass.schema.keys.include?(@method_name)
+
+      schema_keys = @klass.schema.keys
+      if schema_keys.first.is_a?(Symbol)
+        @klass.schema.keys.include?(@method_name)
+      elsif schema_keys.first.respond_to?(:name)
+        @klass.schema.keys.map(&:name).include?(@method_name)
+      else
+        raise "Can't determine schema methods. `Class.schema.keys` returns array of unknown types."
+      end
     end
 
     def schema?

--- a/lib/duckface/services/check_class_implements_interface.rb
+++ b/lib/duckface/services/check_class_implements_interface.rb
@@ -2,6 +2,7 @@
 
 require 'duckface/method_implementation'
 require 'duckface/check_session'
+require 'forwardable'
 
 module Duckface
   module Services

--- a/lib/duckface/version.rb
+++ b/lib/duckface/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Duckface
-  VERSION = '0.0.4'
+  VERSION = '0.0.5'
 end

--- a/spec/lib/duckface/method_implementation_spec.rb
+++ b/spec/lib/duckface/method_implementation_spec.rb
@@ -19,6 +19,17 @@ module Duckface
       end
     end
 
+    class ExampleDryStruct
+      NamedAttributeStruct = Struct.new(:name)
+
+      def self.schema
+        named_attribute = NamedAttributeStruct.new(:my_dry_struct_attribute)
+        {
+          named_attribute => 'String'
+        }
+      end
+    end
+
     let(:method_implementation) { MethodImplementation.new(ExampleMethodTest, :some_method) }
 
     describe '#parameters_for_comparison' do
@@ -44,6 +55,14 @@ module Duckface
 
         it { is_expected.to eq [] }
       end
+
+      context 'with a dry struct' do
+        let(:method_implementation) do
+          MethodImplementation.new(ExampleDryStruct, :my_dry_struct_attribute)
+        end
+
+        it { is_expected.to eq [] }
+      end
     end
 
     describe '#owner' do
@@ -55,6 +74,14 @@ module Duckface
         let(:method_implementation) { MethodImplementation.new(ExampleStruct, :my_struct_attribute) }
 
         it { is_expected.to eq ExampleStruct }
+      end
+
+      context 'with a dry struct' do
+        let(:method_implementation) do
+          MethodImplementation.new(ExampleDryStruct, :my_dry_struct_attribute)
+        end
+
+        it { is_expected.to eq ExampleDryStruct }
       end
     end
   end


### PR DESCRIPTION
Updating things that depend on duckface explode with un-useful error messages unless this is done.